### PR TITLE
feat: add configurable options

### DIFF
--- a/lib/multi-select.js
+++ b/lib/multi-select.js
@@ -9,6 +9,8 @@ const {
 const { text: TextCellType } = Handsontable.cellTypes
 const { KEY_CODES, rangeEach } = Handsontable.helper
 
+const defaultSeparator = ','
+
 const EDITOR_HIDDEN_CLASS_NAME = 'ht_editor_hidden'
 const EDITOR_VISIBLE_CLASS_NAME = 'ht_editor_visible'
 
@@ -31,6 +33,10 @@ const classNamesOverride = {
   button: 'multi-select__choices__button',
 }
 
+const getSeparator = R.path([ 'config', 'separator' ])
+const getLabelKey = R.path([ 'config', 'labelKey' ])
+const getValueKey = R.path([ 'config', 'valueKey' ])
+
 export class MultiSelectEditor extends TextEditor {
   /**
    * Gets current value from editable element.
@@ -39,8 +45,8 @@ export class MultiSelectEditor extends TextEditor {
    */
   getValue () {
     const valueArray = this.choices.getValue()
-    const formattedValues = R.map((value) => value.label, valueArray)
-    return formattedValues.join(',')
+    const formattedValues = R.pluck('label', valueArray)
+    return formattedValues.join(this.separator)
   }
 
   /**
@@ -48,15 +54,7 @@ export class MultiSelectEditor extends TextEditor {
    *
    * @param {*} newValue
    */
-  setValue (newValue) {
-    if (!this.choices) return
-		if (R.isNil(newValue)) {
-			this.choices.setValue([])
-			return
-		}
-
-    const formattedValue = newValue.split(',')
-    this.choices.setValue(formattedValue)
+  setValue () {
   }
 
   /**
@@ -73,6 +71,9 @@ export class MultiSelectEditor extends TextEditor {
     super.prepare(row, col, prop, td, originalValue, cellProperties)
     const selectOptions = R.prop('select', cellProperties)
     this.selectOptions = R.defaultTo({}, selectOptions)
+    this.valueKey = getValueKey(this.selectOptions) || 'value'
+    this.labelKey = getLabelKey(this.selectOptions) || 'label'
+    this.separator = getSeparator(this.selectOptions) || ','
   }
 
   /**
@@ -117,23 +118,35 @@ export class MultiSelectEditor extends TextEditor {
 
     this.choices = new Choices(this.TEXTAREA, {
       classNames: classNamesOverride,
+      delimiter: this.separator,
       removeItemButton: true,
       position: 'bottom',
       itemSelectText: '',
     })
 
-    const allChoices = R.map((choice) => ({
-      value: choice.key,
-      label: choice.text,
-    }), this.selectOptions.options)
+    const getOptions = () => {
+      const { options } = this.selectOptions
+      const toResolve = typeof options === 'function'
+        ? options()
+        : options
+      return Promise.resolve(toResolve)
+        .then(((availableOptions) => {
+          const { originalValue } = this
+          if (R.isEmpty(originalValue) || R.isNil(originalValue)) {
+            return availableOptions
+          }
 
-    const hasCurrentChoice = !R.isNil(this.originalValue) && !R.isEmpty(this.originalValue)
-    const currentChoice = hasCurrentChoice
-      ? R.map((label) => R.find(R.propEq('label', label), allChoices).value, this.originalValue.split(','))
-      : []
+          const selectedValues = originalValue.split(this.separator)
+          return R.map((item) => {
+            const label = R.prop(this.labelKey, item)
+            return R.any(R.identical(label), selectedValues)
+              ? R.assoc('selected', true, item)
+              : item
+          }, availableOptions)
+        }))
+    }
 
-    this.choices.setChoices(allChoices, 'value', 'label', true)
-    this.choices.setChoiceByValue(currentChoice)
+    this.choices.setChoices(getOptions, this.valueKey, this.labelKey, true)
 
     this.choices.showDropdown()
 
@@ -281,7 +294,11 @@ export class MultiSelectEditor extends TextEditor {
 }
 
 export function MultiSelectRenderer (instance, td, row, col, prop, value, cellProperties) {
-  const { options: availableOptions, separator } = cellProperties.select
+  const {
+    config = {},
+    options: availableOptions,
+  } = cellProperties.select
+  const { separator = defaultSeparator } = config
 
   if (typeof availableOptions === 'undefined' || typeof availableOptions.length === 'undefined' || !availableOptions.length) {
     TextCellType.renderer(instance, td, row, col, prop, value, cellProperties)
@@ -289,8 +306,8 @@ export function MultiSelectRenderer (instance, td, row, col, prop, value, cellPr
   }
 
   const stringValue = value ? `${value}` : ''
-  const valueArray = stringValue.split(',')
-  const formattedValue = valueArray.join(separator || ', ')
+  const valueArray = stringValue.split(separator)
+  const formattedValue = valueArray.join(separator)
 
   TextCellType.renderer(instance, td, row, col, prop, formattedValue, cellProperties)
   return td

--- a/web/main.js
+++ b/web/main.js
@@ -1,3 +1,4 @@
+import { pluck } from 'ramda'
 import { MultiSelectEditor, MultiSelectRenderer } from '../lib/multi-select'
 import data from './users'
 import options from './options'
@@ -22,8 +23,16 @@ new Handsontable(sheet, {
       editor: MultiSelectEditor,
       renderer: MultiSelectRenderer,
       select: {
-        config: {},
-        options
+        config: {
+          valueKey: 'key',
+          labelKey: 'text',
+          separator: ';',
+        },
+        options (source, process) {
+          return new Promise((resolve) => {
+            setTimeout(resolve, 500, options)
+          })
+        },
       }
     }
   ]

--- a/web/users.js
+++ b/web/users.js
@@ -4,28 +4,25 @@ export default [
     "Veum",
     "Arturo53@yahoo.com",
     "Dynamic Group Liaison",
-    "Argentina"
   ],
   [
     "Kenneth",
     "Graham",
     "Dario_Simonis@hotmail.com",
     "Corporate Mobility Producer",
-    "Argentina"
   ],
   [
     "Cassandra",
     "Schaefer",
     "Parker64@yahoo.com",
     "Future Applications Analyst",
-    "Argentina"
   ],
   [
     "Oswaldo",
     "Gulgowski",
     "Ruth40@yahoo.com",
     "Regional Response Executive",
-    "Argentina"
+    "Brazil;China"
   ],
   [
     "Mavis",


### PR DESCRIPTION
The value key, label key and separator can now be configured from the
outside of the plugin. This makes things a bit more genric.

Async usage has been added to the demo page.