### PR TITLE
fix: do not use handsontable full

### DIFF
--- a/lib/multi-select.js
+++ b/lib/multi-select.js
@@ -1,4 +1,4 @@
-import Handsontable from 'handsontable/dist/handsontable.full'
+import Handsontable from 'handsontable'
 import Choices from 'choices.js'
 import R from 'ramda'
 

--- a/web/rollup.config.js
+++ b/web/rollup.config.js
@@ -7,7 +7,7 @@ export default {
     file: `${__dirname}/bundle.js`,
     format: 'iife',
     globals: {
-      'handsontable/dist/handsontable.full': 'Handsontable',
+      'handsontable': 'Handsontable',
       'ramda': 'R',
       'choices.js': 'Choices'
     },


### PR DESCRIPTION
Using handsontable full may cause a numbro bug. Better to let the user
care about how to include numbro.