### PR TITLE
feat: add ability for numeric options and max selections

### DIFF
--- a/lib/multi-select.js
+++ b/lib/multi-select.js
@@ -43,6 +43,11 @@ const classNamesOverride = {
 const getSeparator = R.path([ 'config', 'separator' ])
 const getLabelKey = R.path([ 'config', 'labelKey' ])
 const getValueKey = R.path([ 'config', 'valueKey' ])
+const getMaxItemCount = R.path([ 'config', 'maxItemCount' ])
+
+function numberComparator (a, b) {
+  return a.value - b.value
+}
 
 export class MultiSelectEditor extends TextEditor {
   /**
@@ -53,7 +58,8 @@ export class MultiSelectEditor extends TextEditor {
   getValue () {
     const valueArray = this.choices.getValue()
     const formattedValues = R.pluck('label', valueArray)
-    return formattedValues.join(this.separator)
+    const resultString = formattedValues.join(this.separator)
+    return this.type === 'numeric' ? Number(resultString) : resultString
   }
 
   /**
@@ -81,6 +87,8 @@ export class MultiSelectEditor extends TextEditor {
     this.valueKey = getValueKey(this.selectOptions) || 'value'
     this.labelKey = getLabelKey(this.selectOptions) || 'label'
     this.separator = getSeparator(this.selectOptions) || ','
+    this.maxItemCount = getMaxItemCount(this.selectOptions) || -1
+    this.type = cellProperties.type
   }
 
   /**
@@ -124,13 +132,21 @@ export class MultiSelectEditor extends TextEditor {
 
     if (this.choices) this.choices.destroy()
 
-    this.choices = new Choices(this.TEXTAREA, {
+    const choicesOptions = {
       classNames: classNamesOverride,
       delimiter: this.separator,
       removeItemButton: true,
       position: 'bottom',
       itemSelectText: '',
-    })
+      maxItemCount: this.maxItemCount,
+    }
+
+    if (this.type === 'numeric') {
+      Object.assign(choicesOptions, {
+        sorter: numberComparator,
+      })
+    }
+    this.choices = new Choices(this.TEXTAREA, choicesOptions)
 
     const getOptions = () => {
       const { options } = this.selectOptions

--- a/web/main.js
+++ b/web/main.js
@@ -1,11 +1,13 @@
-import { pluck } from 'ramda'
+import { pluck, times } from 'ramda'
 import { MultiSelectEditor, MultiSelectRenderer } from '../lib/multi-select'
 import data from './users'
 import options from './options'
 
 const sheet = document.getElementById('sheet')
 
-const headers = [ 'First name', 'Last name', 'Email', 'Job title', 'Country' ]
+const headers = [ 'First name', 'Last name', 'Email', 'Job title', 'Country', 'Single Number', 'Multi Numbers' ]
+
+const numberOptions = times((i) => ({ key: i, value: i }), 50)
 
 new Handsontable(sheet, {
   data,
@@ -20,6 +22,7 @@ new Handsontable(sheet, {
     {},
     {},
     {
+      type: 'text',
       editor: MultiSelectEditor,
       renderer: MultiSelectRenderer,
       select: {
@@ -31,6 +34,23 @@ new Handsontable(sheet, {
         options (source, process) {
           return new Promise((resolve) => {
             setTimeout(resolve, 500, options)
+          })
+        },
+      }
+    }, {
+      type: 'numeric',
+      editor: MultiSelectEditor,
+      renderer: MultiSelectRenderer,
+      select: {
+        config: {
+          valueKey: 'key',
+          labelKey: 'text',
+          separator: ';',
+          maxItemCount: 1,
+        },
+        options (source, process) {
+          return new Promise((resolve) => {
+            setTimeout(resolve, 500, numberOptions)
           })
         },
       }


### PR DESCRIPTION
The plugin now takes the type option into account. If the type is
`numeric` the plugin will return a `Number` value just like regular
handsontable cells.

Is is also possible to set `maxItemCount`. This will limit the number of
possible choices. Currently it only makes sense to use the limit 1 with
a numeric cell since joined values always will be a string.