### PR TITLE
fix: handle numeric type properly

### DIFF
--- a/lib/multi-select.js
+++ b/lib/multi-select.js
@@ -42,6 +42,8 @@ function numberComparator (a, b) {
   return a.value - b.value
 }
 
+const isNumber = (value) => typeof value === 'number' && isFinite(value)
+
 export class MultiSelectEditor extends TextEditor {
   /**
    * Gets current value from editable element.
@@ -51,8 +53,7 @@ export class MultiSelectEditor extends TextEditor {
   getValue () {
     const valueArray = this.choices.getValue()
     const formattedValues = R.pluck('label', valueArray)
-    const resultString = formattedValues.join(this.separator)
-    return this.type === 'numeric' ? Number(resultString) : resultString
+    return formattedValues.join(this.separator)
   }
 
   /**
@@ -75,13 +76,23 @@ export class MultiSelectEditor extends TextEditor {
    */
   prepare (row, col, prop, td, originalValue, cellProperties) {
     super.prepare(row, col, prop, td, originalValue, cellProperties)
+    const { type } = cellProperties
+    this.type = type
+
     const selectOptions = R.prop('select', cellProperties)
     this.selectOptions = R.defaultTo({}, selectOptions)
+
     this.valueKey = getValueKey(this.selectOptions) || 'value'
     this.labelKey = getLabelKey(this.selectOptions) || 'label'
-    this.separator = getSeparator(this.selectOptions) || ','
-    this.maxItemCount = getMaxItemCount(this.selectOptions) || -1
-    this.type = cellProperties.type
+
+    if (type === 'numeric') {
+      this.separator = ''
+      this.maxItemCount = 1
+      this.originalValue = isNumber(originalValue) ? originalValue.toString() : originalValue
+    } else {
+      this.separator = getSeparator(this.selectOptions) || ','
+      this.maxItemCount = getMaxItemCount(this.selectOptions) || -1
+    }
   }
 
   /**
@@ -151,10 +162,11 @@ export class MultiSelectEditor extends TextEditor {
           if (R.isEmpty(originalValue) || R.isNil(originalValue)) {
             return availableOptions
           }
-
+          
           const selectedValues = originalValue.split(this.separator)
           return R.map((item) => {
-            const label = R.prop(this.labelKey, item)
+            const label = `${R.prop(this.labelKey, item)}`
+
             return R.any(R.identical(label), selectedValues)
               ? R.assoc('selected', true, item)
               : item

--- a/web/main.js
+++ b/web/main.js
@@ -9,7 +9,7 @@ const headers = [ 'First name', 'Last name', 'Email', 'Job title', 'Country', 'S
 
 const numberOptions = times((i) => ({ key: i, value: i }), 50)
 
-new Handsontable(sheet, {
+const hot = new Handsontable(sheet, {
   data,
   licenseKey: 'non-commercial-and-evaluation',
   rowHeaders: true,
@@ -44,9 +44,7 @@ new Handsontable(sheet, {
       select: {
         config: {
           valueKey: 'key',
-          labelKey: 'text',
-          separator: ';',
-          maxItemCount: 1,
+          labelKey: 'value',
         },
         options (source, process) {
           return new Promise((resolve) => {

--- a/web/users.js
+++ b/web/users.js
@@ -29,7 +29,8 @@ export default [
     "McGlynn",
     "Brendan_Hagenes34@hotmail.com",
     "Senior Markets Coordinator",
-    "Argentina"
+    "Argentina",
+    1,
   ],
   [
     "Bernard",


### PR DESCRIPTION
Numeric type will be internally converted into a string to be able to
split it as the text values. Numeric types will also always have a
maxItemCount of 1.