### PR TITLE
fix: handle unselected cells in showEditableElement

### DIFF
--- a/lib/multi-select.js
+++ b/lib/multi-select.js
@@ -154,7 +154,7 @@ export class MultiSelectEditor extends TextEditor {
           if (R.isEmpty(originalValue) || R.isNil(originalValue)) {
             return availableOptions
           }
-          
+
           const selectedValues = originalValue.split(this.separator)
           return R.map((item) => {
             const label = `${R.prop(this.labelKey, item)}`
@@ -194,12 +194,14 @@ export class MultiSelectEditor extends TextEditor {
   * Resets an editable element position.
   */
   showEditableElement() {
+    const editedCell = this.getEditedCell()
+
     this.textareaParentStyle.height = ''
     this.textareaParentStyle.overflow = ''
     this.textareaParentStyle.position = ''
     this.textareaParentStyle.right = 'auto'
     this.textareaParentStyle.opacity = '1'
-    this.textareaParentStyle.width = `${this.getEditedCell().getBoundingClientRect().width}px`
+    this.textareaParentStyle.width = editedCell ? `${editedCell.getBoundingClientRect().width}px` : 'auto'
 
     this.textareaStyle.textIndent = ''
     this.textareaStyle.overflowY = 'hidden'


### PR DESCRIPTION
This commit fixes the problem when internally calling showEditableElement in the multi-select plugin, while the context has no selected cell (or the cell is programmatically disabled) would lead to a crash.

That happened because the logic tried immediatelly pulling bounding rect for the selected cell (even if there was not one marked in the state) without doing the proper checks on the value.

The bug was resolved by providing safety checks for the this.getEditedCell function, which can return null if hot state does not contain information about the selected cell.