### PR TITLE
fix: handle unselected cells in showEditableElement

### DIFF
--- a/lib/multi-select.js
+++ b/lib/multi-select.js
@@ -84,6 +84,7 @@ export class MultiSelectEditor extends TextEditor {
    */
   prepare (row, col, prop, td, originalValue, cellProperties) {
     super.prepare(row, col, prop, td, originalValue, cellProperties)
+    const editedCell = this.getEditedCell()
 
     const { type } = cellProperties
 
@@ -103,7 +104,7 @@ export class MultiSelectEditor extends TextEditor {
     const values = originalValue?.toString().split(this.separator).filter(Boolean)
     this.choices.setValues(values)
 
-    this.textareaParentStyle.width = `${this.getEditedCell().getBoundingClientRect().width}px`
+    this.textareaParentStyle.width = editedCell ? `${editedCell.getBoundingClientRect().width}px` : 'auto'
     this.lastCellInfo = {
       row, col, prop, td, originalValue, cellProperties,
     }
@@ -159,8 +160,10 @@ export class MultiSelectEditor extends TextEditor {
    * Used by the handsontable library.
    */
   showEditableElement () {
+    const editedCell = this.getEditedCell()
+
     this.textareaParentStyle.opacity = '1'
-    this.textareaParentStyle.width = `${this.getEditedCell().getBoundingClientRect().width}px`
+    this.textareaParentStyle.width = editedCell ? `${editedCell.getBoundingClientRect().width}px` : 'auto'
 
     const { childNodes } = this.TEXTAREA_PARENT
     let hasClassHandsontableEditor = false


### PR DESCRIPTION
This commit fixes the problem when internally calling showEditableElement in the multi-select plugin, while the context has no selected cell (or the cell is programmatically disabled) would lead to a crash.

That happened because the logic tried immediatelly pulling bounding rect for the selected cell (even if there was not one marked in the state) without doing the proper checks on the value.

The bug was resolved by providing safety checks for the this.getEditedCell function, which can return null if hot state does not contain information about the selected cell.