### PR TITLE
fix(handsontable-multi-select): add context to options function

### DIFF
--- a/lib/multi-select.js
+++ b/lib/multi-select.js
@@ -146,7 +146,7 @@ export class MultiSelectEditor extends TextEditor {
     const getOptions = () => {
       const { options } = this.selectOptions
       const toResolve = typeof options === 'function'
-        ? options()
+        ? options(this)
         : options
       return Promise.resolve(toResolve)
         .then(((availableOptions) => {


### PR DESCRIPTION
Without "this" there does not seem to be a way to contextually set options through columnSettings, especially before initialization of HoT.