### PR TITLE
fix: filter with search term on get options

### DIFF
--- a/lib/choices-dropdown.js
+++ b/lib/choices-dropdown.js
@@ -312,7 +312,7 @@ export default class ChoicesDropdown {
         return availableOptions
       })
       .then(() => {
-        this.searchOptions()
+        this.searchOptions(searchTerm)
         this.resizeEditor(selectedCell)
       })
   }


### PR DESCRIPTION
Now that options are debounced, it is not given that the search after the get should filter with empty string. There could be a search that needs to be respected even after a new fetch has happened.